### PR TITLE
Update GolangCI-lint to v1.54.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -121,6 +121,6 @@ issues:
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.53.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.54.x # use the fixed version to not introduce new linters unexpectedly
   prepare:
     - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ BINARY_NAME=gradetool
 REGISTRY?=quay.io
 TNF_IMAGE_NAME?=testnetworkfunction/gradetool
 IMAGE_TAG?=latest
-GOLANGCI_VERSION=v1.53.3
+GOLANGCI_VERSION=v1.54.2
 
 .PHONY: build
 


### PR DESCRIPTION
Related to: https://github.com/test-network-function/cnf-certification-test/pull/1367