### PR TITLE
Switch to 1-to-1 result struct

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,6 @@ require (
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
+	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,9 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/test-network-function/test-network-function-claim v1.0.31 h1:Yqb9/8QPEEZO0LAIeuw65uPzDPnKSG8z/njpXAN2CJs=
 github.com/test-network-function/test-network-function-claim v1.0.31/go.mod h1:itpxi9Ehhv9oNC9MiSAt52SKFtJBbQ/T1njTXspl1Hk=
-github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMcyryUHoUjUJX0/lt1H2+i2Ka2n+D3DImSNo=
+github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=

--- a/tool/tool.go
+++ b/tool/tool.go
@@ -152,38 +152,26 @@ func validatePolicySchema(policyPath string) error {
 
 func processTestResults(results interface{}) (bool, error) {
 	pass := false
-	var resultsTyped []interface{}
-	resultsTyped, ok := results.([]interface{})
+	resultTyped, ok := results.(map[string]interface{})
 	if !ok {
-		return pass, fmt.Errorf("the test results object is not of expected type. "+
-			foundExpected, results, resultsTyped)
+		return pass, fmt.Errorf("the test result object is not of expected type. "+
+			foundExpected, results, resultTyped)
 	}
-	for _, result := range resultsTyped {
-		resultTyped, ok := result.(map[string]interface{})
-		if !ok {
-			return pass, fmt.Errorf("the test result object is not of expected type. "+
-				foundExpected, result, resultTyped)
-		}
 
-		val, ok := resultTyped["state"]
-		if !ok {
-			return pass, fmt.Errorf("the field 'state' is missing in test result")
-		}
-
-		pass, ok := val.(string)
-		if !ok {
-			return false, fmt.Errorf("field 'state' is not of type string")
-		}
-
-		switch pass {
-		case "passed":
-			return true, nil
-		case "failed":
-			return false, nil
-		case "skipped":
-			return true, nil
-		}
+	val, ok := resultTyped["state"]
+	if !ok {
+		return pass, fmt.Errorf("the field 'state' is missing in test result")
 	}
+
+	switch val.(string) {
+	case "passed":
+		return true, nil
+	case "failed":
+		return false, nil
+	case "skipped":
+		return true, nil
+	}
+
 	return pass, nil
 }
 


### PR DESCRIPTION
Similar to: https://github.com/test-network-function/cnf-certification-test/pull/1666

The gradetool needs to be updated to be able to parse the incoming result interfaces.

Only merge this when the `ginkgo_removal` branch in the TNF repo is merged.

EDIT: We have decided to cherry-pick the 0.2.0 claim version back to the `main` branch which will allow us to merge this PR at anytime to be able to support the new claim version in both the `ginkgo_removal` and `main` branches.